### PR TITLE
docs: public docstrings

### DIFF
--- a/src/fastapi_easy_versioning/dependency.py
+++ b/src/fastapi_easy_versioning/dependency.py
@@ -12,20 +12,66 @@ since the FastAPI 0.137 router-tree refactor and are not hashable)."""
 
 
 class VersionInfo(NamedTuple):
-    """Resolved versioning metadata of an endpoint."""
+    """Resolved versioning metadata of an endpoint.
+
+    Yielded by the [`versioning`][fastapi_easy_versioning.versioning] dependency
+    when it is injected into an endpoint signature. Both fields are resolved by
+    the middleware against the actually mounted versions, so `until` is a
+    concrete version number even when the endpoint declared none.
+
+    Usage:
+        ```python
+        @app_v1.get("/endpoint")
+        def endpoint(version: Annotated[VersionInfo, Depends(versioning())]) -> str:
+            return f"available from v{version.origin} through v{version.until}"
+        ```
+    """
 
     origin: int
     """The version that declared the endpoint."""
 
     until: int
-    """The last version the endpoint is available in."""
+    """The last version the endpoint is available in.
+
+    When no `until` was declared, this is the latest mounted version at the time
+    versioning was built.
+    """
 
 
 class VersioningSupport:
+    """Callable dependency marking an endpoint as versioned.
+
+    Instances are produced by [`versioning`][fastapi_easy_versioning.versioning]
+    and are meant to be passed to `Depends()`; construct them through that
+    factory rather than directly. An instance only carries the *declared* `until`
+    and is never mutated — the resolved per-route metadata lives in a registry on
+    the version sub-app, so the same instance can safely be shared by a router
+    included into several versions.
+
+    Args:
+        until (int | None, optional): The last supported version, as declared at
+            the call site. Defaults to `None`.
+
+    """
+
     def __init__(self, *, until: int | None = None) -> None:
         self.until = until
 
     async def __call__(self, connection: HTTPConnection) -> VersionInfo:
+        """Resolve the versioning metadata of the route being served.
+
+        Args:
+            connection (HTTPConnection): The current connection, injected by
+                FastAPI for both HTTP requests and WebSocket connections.
+
+        Returns:
+            VersionInfo: The `origin`/`until` pair resolved for this route.
+
+        Raises:
+            RuntimeError: The route was never processed by the middleware — see
+                [`rebuild_versioning`][fastapi_easy_versioning.rebuild_versioning].
+
+        """
         state = getattr(connection.scope.get("app"), "state", None)
         infos: dict[int, VersionInfo] | None = getattr(state, VERSION_INFOS_ATTR, None)
         info = (
@@ -46,6 +92,11 @@ class VersioningSupport:
 def versioning(*, until: int | None = None) -> VersioningSupport:
     """Dependency factory to mark endpoints as versioned.
 
+    Marking is opt-in: an endpoint without this dependency is invisible to
+    versioning and stays only in the version that declares it. Inheritance itself
+    is performed by
+    [`VersioningMiddleware`][fastapi_easy_versioning.VersioningMiddleware].
+
     Usage:
         ```python
         @router.get("/path", dependencies=[Depends(versioning(until=...))])
@@ -64,12 +115,19 @@ def versioning(*, until: int | None = None) -> VersioningSupport:
         ```
 
     Args:
-        until (int | None, optional): The last supported version. If `None`,
-            the endpoint remains available in all versions. Defaults to `None`.
+        until (int | None, optional): The last version the endpoint is available
+            in, inclusive. If `None`, the endpoint remains available through the
+            latest version — including versions mounted later. When a route
+            carries several versioning dependencies (say one on the router and
+            one on the endpoint), the smallest declared `until` wins. An `until`
+            below the declaring version emits a `UserWarning`: the endpoint is
+            then inherited nowhere. Defaults to `None`.
 
     Returns:
         VersioningSupport:
-            A dependency callable compatible with FastAPI's `Depends()`.
+            A dependency callable compatible with FastAPI's `Depends()`. Injected
+            into an endpoint signature, it yields a
+            [`VersionInfo`][fastapi_easy_versioning.VersionInfo].
 
     """
     return VersioningSupport(until=until)

--- a/src/fastapi_easy_versioning/middleware.py
+++ b/src/fastapi_easy_versioning/middleware.py
@@ -23,6 +23,18 @@ if TYPE_CHECKING:
     from starlette.types import ASGIApp, Receive, Scope, Send  # pragma: no cover
 
 API_VERSION_KEY: Final = "api_version"
+"""Name of the `FastAPI()` keyword that declares a sub-app's API version.
+
+Unknown keywords land in `FastAPI.extra`, which is where the middleware reads
+this one from. The value must be an `int` (`0` is valid, `bool` is not); a
+sub-app without it — or with a value of another type, which also emits a
+`UserWarning` — takes no part in versioning.
+
+Usage:
+    ```python
+    app_v1 = FastAPI(api_version=1)  # or FastAPI(**{API_VERSION_KEY: 1})
+    ```
+"""
 
 # Public route-tree iteration API. Since the 0.137 router refactor
 # include_router no longer copies routes into a flat list: router.routes
@@ -58,7 +70,18 @@ class VersioningMiddleware:
     under a single FastAPI instance. On the first ASGI event it inherits versioned
     endpoints from older versions into newer ones and regenerates each version's
     OpenAPI schema. Requests themselves are routed by the mounts; use
-    `rebuild_versioning` to pick up routes added at runtime.
+    [`rebuild_versioning`][fastapi_easy_versioning.rebuild_versioning] to pick up
+    routes added at runtime.
+
+    Add it to the application that **directly mounts** the version sub-apps, never
+    to the sub-apps themselves. Several instances may coexist in one application
+    tree — each versions only the sub-apps mounted directly under its own app, so
+    independent APIs version separately.
+
+    Only endpoints marked with
+    [`versioning`][fastapi_easy_versioning.versioning] are inherited, and a
+    version that declares its own endpoint on the same path shadows the inherited
+    one — at runtime and in the OpenAPI schema alike.
 
     Usage:
         ```python
@@ -68,7 +91,19 @@ class VersioningMiddleware:
         app = FastAPI(middleware=[Middleware(VersioningMiddleware)])
         # or alternatively
         app.add_middleware(VersioningMiddleware)
+
+        app.mount("/v1", FastAPI(api_version=1))
+        app.mount("/v2", FastAPI(api_version=2))
         ```
+
+    Args:
+        app (ASGIApp): The wrapped application, supplied by `add_middleware` or
+            `Middleware` — do not pass it yourself.
+        rebuild_openapi (bool, optional): Regenerate each version's OpenAPI schema
+            after inheritance. With `False` the endpoints are still inherited and
+            served, but inherited ones do not show up in the version's `/docs`.
+            Defaults to `True`.
+
     """
 
     def __init__(self, app: ASGIApp, *, rebuild_openapi: bool = True) -> None:
@@ -86,8 +121,20 @@ class VersioningMiddleware:
 def rebuild_versioning(app: Starlette, *, rebuild_openapi: bool = True) -> None:
     """Build (or explicitly rebuild) versioned routes of an application.
 
-    `VersioningMiddleware` calls this once on its first ASGI event. Call it
-    manually to pick up routes or versions added at runtime after that.
+    [`VersioningMiddleware`][fastapi_easy_versioning.VersioningMiddleware] calls
+    this once on its first ASGI event — the lifespan startup under a real server,
+    the first request when the middleware sits on a mounted sub-app or in a test
+    client. Nothing is versioned before that, and anything registered afterwards
+    needs an explicit call:
+
+    ```python
+    app.mount("/v3", app_v3)
+    rebuild_versioning(app)
+    ```
+
+    The call is idempotent, and a default (undeclared) `until` is re-resolved
+    against the new latest version. An application that mounts no version sub-app
+    is a graceful no-op.
 
     Args:
         app (Starlette): The application that directly mounts the version sub-apps.


### PR DESCRIPTION
## Summary

Expands the docstrings of the package's public names — groundwork for the API Reference section that will be generated by mkdocstrings.

- `VersioningSupport` gains a class docstring and one on `__call__` (what it returns, when it raises `RuntimeError`); `VersionInfo` explains the resolved `until`.
- `versioning()` — spells out the `until` semantics: the minimum across several dependencies, the `UserWarning` when `until` is below the declaring version, and `None` meaning "through the latest version".
- `VersioningMiddleware` — adds an `Args` section for `rebuild_openapi` plus the caveats: aggregating app only, multiple instances, endpoint shadowing.
- `rebuild_versioning()` — documents the build-once behaviour and idempotency; `API_VERSION_KEY` — the requirements on its value type.

No code changes, docstrings only. Cross-references use mkdocstrings syntax.