### PR TITLE
docs: bilingual README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,82 +1,112 @@
-# FastAPI Easy Versioning
+# fastapi-easy-versioning
 
+**English** · [Русский](https://github.com/feodor-ra/fastapi-easy-versioning/blob/master/README.ru.md)
+
+[![PyPI - Version](https://img.shields.io/pypi/v/fastapi-easy-versioning)](https://pypi.org/project/fastapi-easy-versioning/)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/fastapi-easy-versioning)
+![PyPI - Status](https://img.shields.io/pypi/status/fastapi-easy-versioning)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/fastapi-easy-versioning)
+[![FastAPI](https://img.shields.io/badge/FastAPI-0.95%2B-009688?logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com)
+
 ![GitHub Release](https://img.shields.io/github/v/release/feodor-ra/fastapi-easy-versioning)
 ![GitHub Repo stars](https://img.shields.io/github/stars/feodor-ra/fastapi-easy-versioning?style=flat)
-![Test results](https://github.com/feodor-ra/fastapi-easy-versioning/actions/workflows/tests.yml/badge.svg)
+![GitHub last commit](https://img.shields.io/github/last-commit/feodor-ra/fastapi-easy-versioning)
+[![Tests](https://github.com/feodor-ra/fastapi-easy-versioning/actions/workflows/tests.yml/badge.svg)](https://github.com/feodor-ra/fastapi-easy-versioning/actions/workflows/tests.yml)
 [![Coverage Status](https://coveralls.io/repos/github/feodor-ra/fastapi-easy-versioning/badge.svg?branch=master)](https://coveralls.io/github/feodor-ra/fastapi-easy-versioning?branch=master)
-[![Documentation](https://img.shields.io/badge/docs-mkdocs-blue)](https://feodor-ra.github.io/fastapi-easy-versioning/)
+[![Docs](https://img.shields.io/badge/docs-mkdocs-blue)](https://feodor-ra.github.io/fastapi-easy-versioning/)
 
-A library for building versioned APIs with [FastAPI](https://fastapi.tiangolo.com). Each API version is a separate FastAPI sub-application mounted under a common application. The library automatically inherits endpoints from older versions into newer ones and rebuilds each version's OpenAPI schema, so every version's `/docs` always shows its complete, current set of endpoints.
+**Versioned APIs for FastAPI** — one sub-application per version, automatic inheritance of endpoints from older versions into newer ones, and an up-to-date OpenAPI schema for every version.
 
-[Documentation](https://feodor-ra.github.io/fastapi-easy-versioning/)
+Once an API lives in several versions, routes have to be copied between them by hand: `/v2` must serve everything `/v1` served, minus what was deliberately dropped. The copies drift apart, `/v1/docs` and `/v2/docs` start lying, and "which versions is this endpoint even in?" becomes a question for `git blame`. This package makes the availability range a **property of the endpoint**: declare it once, mark it with a dependency, and it shows up in every later version by itself.
 
-## Features
+```python
+app = FastAPI()
+app.add_middleware(VersioningMiddleware)
+app.mount("/v1", app_v1)
+app.mount("/v2", app_v2)
 
-- Endpoint inheritance between versions: declare an endpoint once and it is available in all subsequent versions.
-- Precise availability range control with the `until` parameter.
-- Redefining an endpoint in a newer version shadows the inherited one — both at runtime and in the OpenAPI schema.
-- HTTP and WebSocket endpoints are supported.
-- Versioning metadata (`origin`, `until`) is readable right inside the endpoint.
-- Several independent versioned APIs within one application.
-- The only runtime dependency is `fastapi` (versions from 0.95 up to the latest are supported).
 
-## Installation
+@app_v1.get("/items", dependencies=[Depends(versioning())])
+def items() -> list[Item]:
+    return get_items()
+```
+
+Declared once in v1 — served at `/v1/items` **and** `/v2/items`, and present in both versions' Swagger. No duplicated route, no hand-maintained schema.
+
+## Install
 
 ```bash
 pip install fastapi-easy-versioning
 ```
 
-[PyPI](https://pypi.org/project/fastapi-easy-versioning/)
+Requires Python **3.10+** and FastAPI **≥ 0.95** (`0.137.0` and `0.137.1` are excluded). `fastapi` is the only runtime dependency.
 
-## Quick Start
+## How to use it
 
-Versioning is built from two pieces that only work together:
+Versioning is built from two pieces that work **only together**.
 
-- `VersioningMiddleware` — added to the application that mounts the versions;
-- `versioning()` — a dependency factory that marks an endpoint as versioned.
+**1. Mount one sub-application per version and add the middleware.** The middleware goes on the aggregating application — the one that directly mounts the versions, never on the versions themselves.
 
 ```python
-from fastapi import FastAPI, Depends
+from fastapi import Depends, FastAPI
 from fastapi_easy_versioning import VersioningMiddleware, versioning
 
 app = FastAPI()
-app_v1 = FastAPI(api_version=1)
+app_v1 = FastAPI(api_version=1)  # the version number is an int; 0 is valid
 app_v2 = FastAPI(api_version=2)
 
 app.mount("/v1", app_v1)
 app.mount("/v2", app_v2)
 app.add_middleware(VersioningMiddleware)
+```
 
-@app_v1.get('/only-v1', dependencies=[Depends(versioning(until=1))])
+**2. Mark the endpoints.** Marking is opt-in: an endpoint without the dependency stays in its own version only.
+
+```python
+@app_v1.get("/only-v1", dependencies=[Depends(versioning(until=1))])
 def only_v1() -> str:
     return "Available only in version v1"
 
-@app_v1.get('/all-versions', dependencies=[Depends(versioning())])
+
+@app_v1.get("/all-versions", dependencies=[Depends(versioning())])
 def all_versions() -> str:
     return "Available in all versions starting from v1"
 
-@app_v2.get('/from-v2', dependencies=[Depends(versioning())])
+
+@app_v2.get("/from-v2", dependencies=[Depends(versioning())])
 def from_v2() -> str:
     return "Available starting from v2 and in all future versions"
 ```
 
-The result:
+`versioning()` without `until` means "through the latest version", not "in this one only" — a common source of surprise. The dependency is accepted anywhere FastAPI accepts one, including `APIRouter(dependencies=[...])` to version a whole router at once.
 
-- `/v1/only-v1` responds while `/v2/only-v1` returns 404 — the endpoint is limited by `until=1`.
-- `/v1/all-versions` and `/v2/all-versions` both respond — the endpoint is declared in `v1` and inherited into `v2`.
-- `/v2/from-v2` responds while `/v1/from-v2` returns 404 — the endpoint only appeared in `v2`.
-- `/v1/docs` and `/v2/docs` show exactly the endpoints available in the corresponding version.
+**3. Read the version metadata where you need it.** Injected into the signature, the same dependency yields the resolved range:
 
-## How It Works
+```python
+@app_v1.get("/where-am-i")
+def where_am_i(version: Annotated[VersionInfo, Depends(versioning())]) -> str:
+    return f"Available from v{version.origin} through v{version.until}"
+```
 
-1. Each version is a `FastAPI(api_version=N)` sub-application mounted under a common application: `app.mount("/v1", app_v1)`. `api_version` must be an integer.
-2. On its first ASGI event (server startup or the first request) `VersioningMiddleware` builds the inheritance once: it copies the marked endpoints from older versions into newer ones and rebuilds each version's OpenAPI schema.
-3. Only endpoints with the `versioning()` dependency are inherited. An endpoint without it stays only in the version where it is declared.
-4. Every inheriting version receives its own copy of the route — changes in one version do not affect the others.
+The result: `/v1/only-v1` responds while `/v2/only-v1` is a 404; `/all-versions` responds in both; `/v2/from-v2` responds while `/v1/from-v2` is a 404 — and each version's `/docs` shows exactly what that version serves.
 
-More details — the `versioning` dependency, middleware behavior, adding routes at runtime, FastAPI version compatibility and complete examples — are in the [documentation](https://feodor-ra.github.io/fastapi-easy-versioning/).
+## Why it's cool
+
+- **Declare once, inherit forward** — an endpoint declared in v1 is served by every later version, each with its own copy of the route.
+- **An exact availability range** — `until` caps the last version an endpoint lives in; several markers on one route resolve to the smallest.
+- **Redefinition shadows** — an endpoint of your own on the same path in a newer version replaces the inherited one, at runtime and in OpenAPI alike.
+- **Honest per-version docs** — every version's OpenAPI schema is regenerated after inheritance, so Swagger never drifts from what is actually served.
+- **HTTP and WebSocket** — `APIRoute` and `APIWebSocketRoute` are versioned with identical semantics, and shadowing is kind-aware.
+- **Several independent APIs** — public and private APIs in one application version separately, one middleware per aggregating app.
+- **Nothing but FastAPI** — a single runtime dependency, fully typed (`py.typed`), tested against FastAPI 0.95 through the latest on Python 3.10–3.14.
+
+## Documentation
+
+📖 **[Full documentation](https://feodor-ra.github.io/fastapi-easy-versioning/)** — quickstart, the guide (dependency, middleware, recipes, limitations), runnable examples and an auto-generated API reference. Available in English and Russian.
+
+## License
+
+[MIT](https://github.com/feodor-ra/fastapi-easy-versioning/blob/master/LICENSE).
 
 ---
 
@@ -84,6 +114,9 @@ More details — the `versioning` dependency, middleware behavior, adding routes
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![ty](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json)](https://github.com/astral-sh/ty)
+[![pytest](https://img.shields.io/badge/tested_with-pytest-0A9EDC?logo=pytest&logoColor=white)](https://docs.pytest.org/)
+[![Material for MkDocs](https://img.shields.io/badge/Material_for_MkDocs-526CFE?logo=materialformkdocs&logoColor=white)](https://squidfunk.github.io/mkdocs-material/)
+[![Conventional Commits](https://img.shields.io/badge/Conventional_Commits-1.0.0-FE5196?logo=conventionalcommits&logoColor=white)](https://www.conventionalcommits.org)
 [![Semantic Versions](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--versions-e10079.svg)](https://github.com/feodor-ra/fastapi-easy-versioning/releases)
 
 ![GitHub License](https://img.shields.io/github/license/feodor-ra/fastapi-easy-versioning)

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,0 +1,122 @@
+# fastapi-easy-versioning
+
+[English](https://github.com/feodor-ra/fastapi-easy-versioning/blob/master/README.md) · **Русский**
+
+[![PyPI - Version](https://img.shields.io/pypi/v/fastapi-easy-versioning)](https://pypi.org/project/fastapi-easy-versioning/)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/fastapi-easy-versioning)
+![PyPI - Status](https://img.shields.io/pypi/status/fastapi-easy-versioning)
+![PyPI - Downloads](https://img.shields.io/pypi/dm/fastapi-easy-versioning)
+[![FastAPI](https://img.shields.io/badge/FastAPI-0.95%2B-009688?logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com)
+
+![GitHub Release](https://img.shields.io/github/v/release/feodor-ra/fastapi-easy-versioning)
+![GitHub Repo stars](https://img.shields.io/github/stars/feodor-ra/fastapi-easy-versioning?style=flat)
+![GitHub last commit](https://img.shields.io/github/last-commit/feodor-ra/fastapi-easy-versioning)
+[![Tests](https://github.com/feodor-ra/fastapi-easy-versioning/actions/workflows/tests.yml/badge.svg)](https://github.com/feodor-ra/fastapi-easy-versioning/actions/workflows/tests.yml)
+[![Coverage Status](https://coveralls.io/repos/github/feodor-ra/fastapi-easy-versioning/badge.svg?branch=master)](https://coveralls.io/github/feodor-ra/fastapi-easy-versioning?branch=master)
+[![Docs](https://img.shields.io/badge/docs-mkdocs-blue)](https://feodor-ra.github.io/fastapi-easy-versioning/ru/)
+
+**Версионированные API на FastAPI** — одно субприложение на версию, автоматическое наследование эндпоинтов из старых версий в новые и своя актуальная OpenAPI-схема у каждой версии.
+
+Когда API живёт в нескольких версиях, между ними приходится вручную копировать роуты: `/v2` должен отдавать всё, что отдавал `/v1`, кроме того, что осознанно выпилили. Копии расползаются, `/v1/docs` и `/v2/docs` начинают врать, а «в какой версии этот эндпоинт вообще есть» становится вопросом к `git blame`. Этот пакет делает диапазон доступности **свойством эндпоинта**: объявляете его один раз, помечаете зависимостью — и он сам оказывается во всех последующих версиях.
+
+```python
+app = FastAPI()
+app.add_middleware(VersioningMiddleware)
+app.mount("/v1", app_v1)
+app.mount("/v2", app_v2)
+
+
+@app_v1.get("/items", dependencies=[Depends(versioning())])
+def items() -> list[Item]:
+    return get_items()
+```
+
+Объявлен один раз в v1 — обслуживается и по `/v1/items`, и по `/v2/items`, и присутствует в Swagger обеих версий. Без дублирования роута и без схемы, поддерживаемой руками.
+
+## Установка
+
+```bash
+pip install fastapi-easy-versioning
+```
+
+Требуется Python **3.10+** и FastAPI **≥ 0.95** (версии `0.137.0` и `0.137.1` исключены). `fastapi` — единственная рантайм-зависимость.
+
+## Как это использовать
+
+Версионирование строится из двух частей, которые работают **только вместе**.
+
+**1. Смонтируйте по субприложению на версию и добавьте middleware.** Middleware добавляется в агрегирующее приложение — то, которое непосредственно монтирует версии, — но не в сами версии.
+
+```python
+from fastapi import Depends, FastAPI
+from fastapi_easy_versioning import VersioningMiddleware, versioning
+
+app = FastAPI()
+app_v1 = FastAPI(api_version=1)  # номер версии — целое число; 0 допустим
+app_v2 = FastAPI(api_version=2)
+
+app.mount("/v1", app_v1)
+app.mount("/v2", app_v2)
+app.add_middleware(VersioningMiddleware)
+```
+
+**2. Пометьте эндпоинты.** Пометка обязательна: эндпоинт без зависимости остаётся только в своей версии.
+
+```python
+@app_v1.get("/only-v1", dependencies=[Depends(versioning(until=1))])
+def only_v1() -> str:
+    return "Я доступен только в версии v1"
+
+
+@app_v1.get("/all-versions", dependencies=[Depends(versioning())])
+def all_versions() -> str:
+    return "Я доступен во всех версиях, начиная с v1"
+
+
+@app_v2.get("/from-v2", dependencies=[Depends(versioning())])
+def from_v2() -> str:
+    return "Я доступен начиная с версии v2 и во всех последующих"
+```
+
+`versioning()` без `until` означает «до последней версии», а не «только в этой» — частый источник недоразумений. Зависимость принимается везде, где её принимает FastAPI, в том числе в `APIRouter(dependencies=[...])`, чтобы разом версионировать весь роутер.
+
+**3. Читайте метаданные версии там, где нужно.** Внедрённая в сигнатуру, та же зависимость возвращает разрешённый диапазон:
+
+```python
+@app_v1.get("/where-am-i")
+def where_am_i(version: Annotated[VersionInfo, Depends(versioning())]) -> str:
+    return f"Доступен с v{version.origin} по v{version.until}"
+```
+
+В результате: `/v1/only-v1` отвечает, а `/v2/only-v1` возвращает 404; `/all-versions` отвечает в обеих версиях; `/v2/from-v2` отвечает, а `/v1/from-v2` возвращает 404 — и `/docs` каждой версии показывает ровно то, что эта версия обслуживает.
+
+## Почему это круто
+
+- **Объявил один раз — наследуется дальше**: эндпоинт из v1 обслуживается всеми последующими версиями, и каждая получает собственную копию роута.
+- **Точный диапазон доступности**: `until` задаёт последнюю версию, в которой живёт эндпоинт; из нескольких пометок на роуте действует минимальная.
+- **Переопределение затеняет**: свой эндпоинт на том же пути в новой версии заменяет унаследованный — и в рантайме, и в OpenAPI.
+- **Честная документация версии**: после наследования OpenAPI-схема каждой версии перестраивается, поэтому Swagger не расходится с тем, что реально обслуживается.
+- **HTTP и WebSocket**: `APIRoute` и `APIWebSocketRoute` версионируются с одинаковой семантикой, а затенение учитывает вид роута.
+- **Несколько независимых API**: public и private API в одном приложении версионируются раздельно — по одному middleware на каждое агрегирующее приложение.
+- **Ничего, кроме FastAPI**: единственная рантайм-зависимость, полная типизация (`py.typed`), тесты против FastAPI от 0.95 до новейшей на Python 3.10–3.14.
+
+## Документация
+
+📖 **[Полная документация](https://feodor-ra.github.io/fastapi-easy-versioning/ru/)** — быстрый старт, руководство (зависимость, middleware, рецепты, ограничения), запускаемые примеры и авто-генерируемый справочник API. Доступна на русском и английском.
+
+## Лицензия
+
+[MIT](https://github.com/feodor-ra/fastapi-easy-versioning/blob/master/LICENSE).
+
+---
+
+[![Pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/feodor-ra/fastapi-easy-versioning/blob/master/.pre-commit-config.yaml)
+[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![ty](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json)](https://github.com/astral-sh/ty)
+[![pytest](https://img.shields.io/badge/tested_with-pytest-0A9EDC?logo=pytest&logoColor=white)](https://docs.pytest.org/)
+[![Material for MkDocs](https://img.shields.io/badge/Material_for_MkDocs-526CFE?logo=materialformkdocs&logoColor=white)](https://squidfunk.github.io/mkdocs-material/)
+[![Conventional Commits](https://img.shields.io/badge/Conventional_Commits-1.0.0-FE5196?logo=conventionalcommits&logoColor=white)](https://www.conventionalcommits.org)
+[![Semantic Versions](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--versions-e10079.svg)](https://github.com/feodor-ra/fastapi-easy-versioning/releases)
+
+![GitHub License](https://img.shields.io/github/license/feodor-ra/fastapi-easy-versioning)


### PR DESCRIPTION
## Summary

Reworks the README along the lines of [fastapi-typed-errors](https://github.com/feodor-ra/fastapi-typed-errors) and adds a Russian counterpart.

- `README.md` (English, also the PyPI long description) — language switcher in the header, a fuller badge block (PyPI version/status, FastAPI, last commit) and a rewritten body: the problem it solves, a compact example, install, three usage steps, "Why it's cool", documentation, license.
- `README.ru.md` — a first-class translation, not a machine one, linking to the Russian docs.

All links in both files are absolute GitHub/docs URLs: relative links break on the PyPI project page, which renders `README.md` outside the repository.

The quickstart stays in sync with `docs/{en,ru}/index.md`, as it is a near-verbatim copy of the same example.