### PR TITLE
docs: colour mermaid nodes with classDef

### DIFF
--- a/docs/en/examples/multiple.md
+++ b/docs/en/examples/multiple.md
@@ -108,28 +108,17 @@ graph TD
     C --> C1[v1<br/>api_version=1]
     C --> C2[v2<br/>api_version=2]
 
-    B1 --> B11["/endpoint ✓<br/>(until=1)"]
-    B1 --> B12["/another-endpoint ✓"]
+    B1 --> B11["/endpoint ✓<br/>(until=1)"]:::available
+    B1 --> B12["/another-endpoint ✓"]:::available
 
-    B2 --> B21["/endpoint ✓<br/>(from v2)"]
-    B2 --> B22["/another-endpoint ✓"]
+    B2 --> B21["/endpoint ✓<br/>(from v2)"]:::available
+    B2 --> B22["/another-endpoint ✓"]:::available
 
-    C1 --> C11["/endpoint ✓<br/>(until=1)"]
-    C1 --> C12["/another-endpoint ✓"]
+    C1 --> C11["/endpoint ✓<br/>(until=1)"]:::available
+    C1 --> C12["/another-endpoint ✓"]:::available
 
-    C2 --> C21["/endpoint ✓<br/>(from v2)"]
-    C2 --> C22["/another-endpoint ✓"]
+    C2 --> C21["/endpoint ✓<br/>(from v2)"]:::available
+    C2 --> C22["/another-endpoint ✓"]:::available
 
-    style B11 fill:#90EE90,color:#1b1b1b
-    style B12 fill:#90EE90,color:#1b1b1b
-    style B21 fill:#90EE90,color:#1b1b1b
-    style B22 fill:#90EE90,color:#1b1b1b
-
-    style C11 fill:#90EE90,color:#1b1b1b
-    style C12 fill:#90EE90,color:#1b1b1b
-    style C21 fill:#90EE90,color:#1b1b1b
-    style C22 fill:#90EE90,color:#1b1b1b
-
-    classDef available fill:#90EE90,color:#1b1b1b,stroke:#333;
-    classDef notAvailable fill:#FFB6C1,color:#1b1b1b,stroke:#333;
+    classDef available fill:#90EE90,stroke:#333,color:#1b1b1b
 ```

--- a/docs/en/examples/simple.md
+++ b/docs/en/examples/simple.md
@@ -84,28 +84,17 @@ graph TD
     A --> C[v2<br/>api_version=2]
     A --> D[v3<br/>api_version=3]
 
-    B --> B1["/endpoint ✓<br/>(until=2)"]
-    B --> B2["/another-endpoint ✓"]
+    B --> B1["/endpoint ✓<br/>(until=2)"]:::available
+    B --> B2["/another-endpoint ✓"]:::available
 
-    C --> C1["/endpoint ✓<br/>(until=2)"]
-    C --> C2["/another-endpoint ✓"]
-    C --> C3["/new-another-endpoint ✓"]
+    C --> C1["/endpoint ✓<br/>(until=2)"]:::available
+    C --> C2["/another-endpoint ✓"]:::available
+    C --> C3["/new-another-endpoint ✓"]:::available
 
-    D --> D1["/endpoint ✗<br/>(until=2)"]
-    D --> D2["/another-endpoint ✓<br/>(overridden in v3)"]
-    D --> D3["/new-another-endpoint ✓"]
+    D --> D1["/endpoint ✗<br/>(until=2)"]:::missing
+    D --> D2["/another-endpoint ✓<br/>(overridden in v3)"]:::available
+    D --> D3["/new-another-endpoint ✓"]:::available
 
-    style B1 fill:#90EE90,color:#1b1b1b
-    style B2 fill:#90EE90,color:#1b1b1b
-
-    style C1 fill:#90EE90,color:#1b1b1b
-    style C2 fill:#90EE90,color:#1b1b1b
-    style C3 fill:#90EE90,color:#1b1b1b
-
-    style D1 fill:#FFB6C1,color:#1b1b1b
-    style D2 fill:#90EE90,color:#1b1b1b
-    style D3 fill:#90EE90,color:#1b1b1b
-
-    classDef available fill:#90EE90,color:#1b1b1b,stroke:#333;
-    classDef notAvailable fill:#FFB6C1,color:#1b1b1b,stroke:#333;
+    classDef available fill:#90EE90,stroke:#333,color:#1b1b1b
+    classDef missing fill:#FFB6C1,stroke:#333,color:#1b1b1b
 ```

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -67,21 +67,16 @@ graph TD
     A --> B[v1]
     A --> C[v2]
 
-    B --> B1["/only-v1 ✓"]
-    B --> B2["/all-versions ✓"]
-    B --> B3["/from-v2 ✗"]
+    B --> B1["/only-v1 ✓"]:::available
+    B --> B2["/all-versions ✓"]:::available
+    B --> B3["/from-v2 ✗"]:::missing
 
-    C --> C1["/only-v1 ✗"]
-    C --> C2["/all-versions ✓"]
-    C --> C3["/from-v2 ✓"]
+    C --> C1["/only-v1 ✗"]:::missing
+    C --> C2["/all-versions ✓"]:::available
+    C --> C3["/from-v2 ✓"]:::available
 
-    style B1 fill:#90EE90,color:#1b1b1b
-    style B2 fill:#90EE90,color:#1b1b1b
-    style B3 fill:#FFB6C1,color:#1b1b1b
-
-    style C1 fill:#FFB6C1,color:#1b1b1b
-    style C2 fill:#90EE90,color:#1b1b1b
-    style C3 fill:#90EE90,color:#1b1b1b
+    classDef available fill:#90EE90,stroke:#333,color:#1b1b1b
+    classDef missing fill:#FFB6C1,stroke:#333,color:#1b1b1b
 ```
 
 ## Features

--- a/docs/ru/examples/multiple.md
+++ b/docs/ru/examples/multiple.md
@@ -108,28 +108,17 @@ graph TD
     C --> C1[v1<br/>api_version=1]
     C --> C2[v2<br/>api_version=2]
 
-    B1 --> B11["/endpoint ✓<br/>(until=1)"]
-    B1 --> B12["/another-endpoint ✓"]
+    B1 --> B11["/endpoint ✓<br/>(until=1)"]:::available
+    B1 --> B12["/another-endpoint ✓"]:::available
 
-    B2 --> B21["/endpoint ✓<br/>(from v2)"]
-    B2 --> B22["/another-endpoint ✓"]
+    B2 --> B21["/endpoint ✓<br/>(from v2)"]:::available
+    B2 --> B22["/another-endpoint ✓"]:::available
 
-    C1 --> C11["/endpoint ✓<br/>(until=1)"]
-    C1 --> C12["/another-endpoint ✓"]
+    C1 --> C11["/endpoint ✓<br/>(until=1)"]:::available
+    C1 --> C12["/another-endpoint ✓"]:::available
 
-    C2 --> C21["/endpoint ✓<br/>(from v2)"]
-    C2 --> C22["/another-endpoint ✓"]
+    C2 --> C21["/endpoint ✓<br/>(from v2)"]:::available
+    C2 --> C22["/another-endpoint ✓"]:::available
 
-    style B11 fill:#90EE90,color:#1b1b1b
-    style B12 fill:#90EE90,color:#1b1b1b
-    style B21 fill:#90EE90,color:#1b1b1b
-    style B22 fill:#90EE90,color:#1b1b1b
-
-    style C11 fill:#90EE90,color:#1b1b1b
-    style C12 fill:#90EE90,color:#1b1b1b
-    style C21 fill:#90EE90,color:#1b1b1b
-    style C22 fill:#90EE90,color:#1b1b1b
-
-    classDef available fill:#90EE90,color:#1b1b1b,stroke:#333;
-    classDef notAvailable fill:#FFB6C1,color:#1b1b1b,stroke:#333;
+    classDef available fill:#90EE90,stroke:#333,color:#1b1b1b
 ```

--- a/docs/ru/examples/simple.md
+++ b/docs/ru/examples/simple.md
@@ -84,28 +84,17 @@ graph TD
     A --> C[v2<br/>api_version=2]
     A --> D[v3<br/>api_version=3]
 
-    B --> B1["/endpoint ✓<br/>(until=2)"]
-    B --> B2["/another-endpoint ✓"]
+    B --> B1["/endpoint ✓<br/>(until=2)"]:::available
+    B --> B2["/another-endpoint ✓"]:::available
 
-    C --> C1["/endpoint ✓<br/>(until=2)"]
-    C --> C2["/another-endpoint ✓"]
-    C --> C3["/new-another-endpoint ✓"]
+    C --> C1["/endpoint ✓<br/>(until=2)"]:::available
+    C --> C2["/another-endpoint ✓"]:::available
+    C --> C3["/new-another-endpoint ✓"]:::available
 
-    D --> D1["/endpoint ✗<br/>(until=2)"]
-    D --> D2["/another-endpoint ✓<br/>(перекрыт в v3)"]
-    D --> D3["/new-another-endpoint ✓"]
+    D --> D1["/endpoint ✗<br/>(until=2)"]:::missing
+    D --> D2["/another-endpoint ✓<br/>(перекрыт в v3)"]:::available
+    D --> D3["/new-another-endpoint ✓"]:::available
 
-    style B1 fill:#90EE90,color:#1b1b1b
-    style B2 fill:#90EE90,color:#1b1b1b
-
-    style C1 fill:#90EE90,color:#1b1b1b
-    style C2 fill:#90EE90,color:#1b1b1b
-    style C3 fill:#90EE90,color:#1b1b1b
-
-    style D1 fill:#FFB6C1,color:#1b1b1b
-    style D2 fill:#90EE90,color:#1b1b1b
-    style D3 fill:#90EE90,color:#1b1b1b
-
-    classDef available fill:#90EE90,color:#1b1b1b,stroke:#333;
-    classDef notAvailable fill:#FFB6C1,color:#1b1b1b,stroke:#333;
+    classDef available fill:#90EE90,stroke:#333,color:#1b1b1b
+    classDef missing fill:#FFB6C1,stroke:#333,color:#1b1b1b
 ```

--- a/docs/ru/index.md
+++ b/docs/ru/index.md
@@ -67,21 +67,16 @@ graph TD
     A --> B[v1]
     A --> C[v2]
 
-    B --> B1["/only-v1 ✓"]
-    B --> B2["/all-versions ✓"]
-    B --> B3["/from-v2 ✗"]
+    B --> B1["/only-v1 ✓"]:::available
+    B --> B2["/all-versions ✓"]:::available
+    B --> B3["/from-v2 ✗"]:::missing
 
-    C --> C1["/only-v1 ✗"]
-    C --> C2["/all-versions ✓"]
-    C --> C3["/from-v2 ✓"]
+    C --> C1["/only-v1 ✗"]:::missing
+    C --> C2["/all-versions ✓"]:::available
+    C --> C3["/from-v2 ✓"]:::available
 
-    style B1 fill:#90EE90,color:#1b1b1b
-    style B2 fill:#90EE90,color:#1b1b1b
-    style B3 fill:#FFB6C1,color:#1b1b1b
-
-    style C1 fill:#FFB6C1,color:#1b1b1b
-    style C2 fill:#90EE90,color:#1b1b1b
-    style C3 fill:#90EE90,color:#1b1b1b
+    classDef available fill:#90EE90,stroke:#333,color:#1b1b1b
+    classDef missing fill:#FFB6C1,stroke:#333,color:#1b1b1b
 ```
 
 ## Возможности


### PR DESCRIPTION
## Summary

Switches the version-availability diagrams from per-node `style` lines to mermaid's own class mechanism — `classDef` plus the `:::` operator on the node.

- Two semantic classes, `available` and `missing`, replace up to nine hand-written `style` statements per diagram; the intent now reads off the node itself (`B1["/only-v1 ✓"]:::available`).
- The example pages already declared `classDef available`/`notAvailable` but never applied them — dead declarations are now the actual mechanism, and the unused one is gone.
- Colours are unchanged, including the explicit `color:` that keeps the labels readable in the slate scheme.

Net effect: −108/+54 lines across the six diagram pages. `uv run mkdocs build --strict` is clean and all three diagrams were verified rendering against mermaid 11 in the dark theme.